### PR TITLE
Ubuntu に入れた tmux 3.0a で動くようにした

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -31,30 +31,22 @@ set -g mouse on
 set -g default-terminal "screen-256color"
 
 # ステータスバーの色を設定する
-set -g status-fg white
-set -g status-bg black
+set -g status-style fg=white,bg=black
 
 # ウィンドウリストの色を設定する
-setw -g window-status-fg cyan
-setw -g window-status-bg default
-setw -g window-status-attr dim
+setw -g window-status-style fg=cyan,bg=default,dim
 
 # アクティブなウィンドウを目立たせる
-setw -g window-status-current-fg white
-setw -g window-status-current-bg red
-setw -g window-status-current-attr bright
+setw -g window-status-current-style fg=white,bg=red,bright
 
 # ペインボーダーの色を設定する
-set -g pane-border-fg green
-set -g pane-border-bg black
+set -g pane-border-style fg=green,bg=black
 
 # アクティブなペインを目立たせる
-set -g pane-active-border-fg white
-set -g pane-active-border-bg yellow
+set -g pane-active-border-style fg=white,bg=yellow
 
 # コマンドラインの色を設定する
-set -g message-fg white
-set -g message-bg black
+set -g message-style fg=white,bg=black
 
 # vim風に移動する
 bind h select-pane -L
@@ -64,9 +56,6 @@ bind l select-pane -R
 
 # pain の index を 1オリジンにする
 set-option -g base-index 1
-
-# Mac OS X pasteboardを使用できるようにする
-set-option -g default-command "reattach-to-user-namespace -l zsh"
 
 # コピーモードでvimキーバインドを使う
 setw -g mode-keys vi


### PR DESCRIPTION
WSL2 で Ubuntu を使うようになったので、そこで tmux を入れた。
それに伴い、以下の変更をした。
- macOS に依存した処理を削除した（今後 macOS を使う予定は今のところない）
- インストールした tmux 3.0a までに仕様が変更されたオプション記法に則るようにした

オプションの記法変更には以下のスクリプトを使わせてもらった。
https://gist.github.com/tbutts/6abf7fb5b948c066bf180922fb37adcf

