### PR TITLE
ノーマルモード時に縦棒カーソルだと挙動がわかりづらいのでカーソルを変えた

### DIFF
--- a/.vimrc.local
+++ b/.vimrc.local
@@ -6,3 +6,12 @@ colorscheme dracula
 set cursorline
 " カーソルがある行をバーで強調表示する
 hi CursorLine term=bold cterm=bold guibg=Grey42
+
+if has('vim_starting')
+  " 挿入モード時に非点滅の縦棒タイプのカーソル
+  let &t_SI .= "\e[6 q"
+  " ノーマルモード時に非点滅のブロックタイプのカーソル
+  let &t_EI .= "\e[2 q"
+  " 置換モード時に非点滅の下線タイプのカーソル
+  let &t_SR .= "\e[4 q"
+endif


### PR DESCRIPTION
Vim のノーマルモードで `v` を使って範囲選択をしたいときに、縦棒カーソルだとどこの文字から選択が開始されるのかわかりづらかったので、カーソル形状を変更した。