### PR TITLE
Windows Terminal の見た目とデフォルトプロファイルを変えた

### DIFF
--- a/windows_terminal/settings.json
+++ b/windows_terminal/settings.json
@@ -8,7 +8,7 @@
 {
     "$schema": "https://aka.ms/terminal-profiles-schema",
 
-    "defaultProfile": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
+    "defaultProfile": "{2c4de342-38b7-51cf-b940-2309a097f518}",
 
     // You can add more global application settings here.
     // To learn more about global settings, visit https://aka.ms/terminal-global-settings

--- a/windows_terminal/settings.json
+++ b/windows_terminal/settings.json
@@ -27,9 +27,12 @@
     {
         "defaults":
         {
-            "colorScheme": "One Half Dark"
             // Put settings here that you want to apply to all profiles.
+            "colorScheme": "Dracula",
+            "fontSize": 9,
+            "fontFace": "Ricty Diminished"
         },
+
         "list":
         [
             {
@@ -63,7 +66,32 @@
 
     // Add custom color schemes to this array.
     // To learn more about color schemes, visit https://aka.ms/terminal-color-schemes
-    "schemes": [],
+    "schemes":
+    [
+        {
+            "name": "Dracula",
+            "cursorColor": "#F8F8F2",
+            "selectionBackground": "#44475A",
+            "background": "#282A36",
+            "foreground": "#F8F8F2",
+            "black": "#21222C",
+            "blue": "#BD93F9",
+            "cyan": "#8BE9FD",
+            "green": "#50FA7B",
+            "purple": "#FF79C6",
+            "red": "#FF5555",
+            "white": "#F8F8F2",
+            "yellow": "#F1FA8C",
+            "brightBlack": "#6272A4",
+            "brightBlue": "#D6ACFF",
+            "brightCyan": "#A4FFFF",
+            "brightGreen": "#69FF94",
+            "brightPurple": "#FF92DF",
+            "brightRed": "#FF6E6E",
+            "brightWhite": "#FFFFFF",
+            "brightYellow": "#FFFFA5"
+        }
+    ],
 
     // Add custom actions and keybindings to this array.
     // To unbind a key combination from your defaults.json, set the command to "unbound".


### PR DESCRIPTION
デフォルトの設定が見づらかったので、フォント種類、フォントサイズ、カラースキームの変更をした。
以下を参考にした。

- https://docs.microsoft.com/ja-jp/windows/terminal/customize-settings/color-schemes
- https://docs.microsoft.com/ja-jp/windows/terminal/customize-settings/profile-settings
- https://draculatheme.com/windows-terminal

また、Windows Terminal 起動時のデフォルトプロファイルが PowerShell になっており不便だったので、WSL にした。