### PR TITLE
tmux 起動時のデフォルトシェルを zsh にした

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -70,3 +70,6 @@ bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "reattach-to-us
 
 # ']' でpbpasteを使う
 bind ] run "reattach-to-user-namespace pbpaste | tmux load-buffer - && tmux paste-buffer"
+
+# tmux 起動時に使う shell を zsh にする
+set-option -g default-shell "/usr/bin/zsh"


### PR DESCRIPTION
WSL 起動時は bash が動いているが、zsh を使いたいので zsh をデフォルトにした。
WSL で直接 `chsh` せずにあえて tmux の起動時の設定としているのは、WSL 起動時に作動する bash の設定で、WSL がトラブルなく動くようにするための設定を読み込んでいたりするとしたら、結果的にそれを強制的にスキップすることになってしまうため。