### PR TITLE
WSL で使う Ubuntu のバージョンを変えた

### DIFF
--- a/windows_terminal/settings.json
+++ b/windows_terminal/settings.json
@@ -8,7 +8,7 @@
 {
     "$schema": "https://aka.ms/terminal-profiles-schema",
 
-    "defaultProfile": "{2c4de342-38b7-51cf-b940-2309a097f518}",
+    "defaultProfile": "{07b52e3e-de2c-5db4-bd2d-ba144ed6c273}",
 
     // You can add more global application settings here.
     // To learn more about global settings, visit https://aka.ms/terminal-global-settings
@@ -32,7 +32,6 @@
             "fontSize": 9,
             "fontFace": "Ricty Diminished"
         },
-
         "list":
         [
             {
@@ -50,16 +49,16 @@
                 "hidden": false
             },
             {
+                "guid": "{07b52e3e-de2c-5db4-bd2d-ba144ed6c273}",
+                "hidden": false,
+                "name": "Ubuntu-20.04",
+                "source": "Windows.Terminal.Wsl"
+            },
+            {
                 "guid": "{b453ae62-4e3d-5e58-b989-0a998ec441b8}",
                 "hidden": false,
                 "name": "Azure Cloud Shell",
                 "source": "Windows.Terminal.Azure"
-            },
-            {
-                "guid": "{2c4de342-38b7-51cf-b940-2309a097f518}",
-                "hidden": false,
-                "name": "Ubuntu",
-                "source": "Windows.Terminal.Wsl"
             }
         ]
     },


### PR DESCRIPTION
前回 WSL で Docker Desktop for Windows との integration を使おうとしたときにまったくうまくいかなかったので、うまくいっている人と同じ状態を作りたいと思い、Ubuntu のバージョンを変えた。
（これのおかげかはわからないが、結果的にこの設定で Docker はうまく動いている）