### PR TITLE
g pl --rebase だと結局打鍵数が多くて辛いのでエイリアスをつくた

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -11,6 +11,7 @@
 	f = fetch
 	df = diff
 	pl = pull
+	plr = pull --rebase
 	ps = push
 	pr = pull --rebase
 	ad = add

--- a/.gitconfig
+++ b/.gitconfig
@@ -13,7 +13,6 @@
 	pl = pull
 	plr = pull --rebase
 	ps = push
-	pr = pull --rebase
 	ad = add
 [core]
 	excludesfile = /Users/yucao24hours/.gitignore


### PR DESCRIPTION
`git pull` を `g pl` で実行できるようにしたものの、 `--rebase` をつけると結局打鍵数が多くなってつらいのでエイリアスにした。

`git pull` の挙動のデフォルトを `--rebase` にするという手もあるが、明示的につけて安心したい派なのでそれは採用しなかった。
